### PR TITLE
Support for content types

### DIFF
--- a/tests/json_to_url.py
+++ b/tests/json_to_url.py
@@ -1,0 +1,22 @@
+import json
+from urllib.parse import quote
+
+from tests.test_create_booking import test_data_json
+
+
+def data_to_url(data: dict, prefix='', wrapper='{}'):
+
+    url_components = list()
+    for key, value in data.items():
+        wrapped_key = wrapper.format(key)
+        prefixed_key = quote(prefix + wrapped_key)
+        # prefixed_key = prefix + wrapped_key
+        if isinstance(value, dict) is False:
+            url_components.append(f"{prefixed_key}={value}")
+        else:
+            url_components.append(f"{data_to_url(value, prefixed_key, '[{}]')}")
+    return "&".join(url_components)
+
+if __name__ == '__main__':
+    data_ = json.load(open(test_data_json, 'r'))
+    print(data_to_url(data_))

--- a/tests/test_create_booking.py
+++ b/tests/test_create_booking.py
@@ -1,8 +1,8 @@
-import json
 import os
 from dataclasses import dataclass
 from datetime import datetime
 
+import pytest
 from hamcrest import assert_that, equal_to
 from requests import post
 
@@ -10,7 +10,9 @@ URL = "https://restful-booker.herokuapp.com/booking"
 project_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 tests_path = os.path.join(project_path, "tests")
 test_data_path = os.path.join(tests_path, "test_data")
-test_data_file = os.path.join(test_data_path, "create_booking.json")
+test_data_json = os.path.join(test_data_path, "create_booking.json")
+test_data_xml = os.path.join(test_data_path, "create_booking.xml")
+test_data_url = os.path.join(test_data_path, "create_booking.txt")
 
 @dataclass
 class BookingData:
@@ -36,8 +38,15 @@ class BookingData:
             additionalneeds=data["booking"]["additionalneeds"],
         )
 
-def test_create_booking():
+params = [
+    ("application/json", test_data_json),
+    ("application/xml", test_data_xml),
+    ("application/x-www-form-urlencoded", test_data_url),
+]
+
+@pytest.mark.parametrize("content_type, testdata", params)
+def test_create_booking(content_type, testdata):
     headers = {'Content-Type': 'application/json'}
-    data = open(test_data_file, 'rb')
+    data = open(test_data_json, 'rb')
     response = post(URL, data=data, headers=headers)
     assert_that(response.status_code, equal_to(200), f"Received {response.status_code} instead of 200")

--- a/tests/test_data/create_booking.json
+++ b/tests/test_data/create_booking.json
@@ -1,11 +1,11 @@
 {
-    "firstname" : "Romuald",
-    "lastname" : "Mean",
-    "totalprice" : 111,
-    "depositpaid" : true,
-    "bookingdates" : {
-        "checkin" : "2020-03-12",
-        "checkout" : "2020-03-25"
+    "firstname": "Romuald",
+    "lastname": "Mean",
+    "totalprice": 111,
+    "depositpaid": true,
+    "bookingdates": {
+        "checkin": "2020-03-12",
+        "checkout": "2020-03-25"
     },
-    "additionalneeds" : "Yellow rubber duck"
+    "additionalneeds": "Yellow rubber duck"
 }

--- a/tests/test_data/create_booking.txt
+++ b/tests/test_data/create_booking.txt
@@ -1,0 +1,1 @@
+firstname=Romuald&lastname=Mean&totalprice=111&depositpaid=True&bookingdates%5Bcheckin%5D=2020-03-12&bookingdates%5Bcheckout%5D=2020-03-25&bookingdates%255Bcheckinbetween%255D%5Ba%5D=1&bookingdates%255Bcheckinbetween%255D%5Bb%5D=2&bookingdates%255Bcheckinbetween%255D%5Bc%5D=3&additionalneeds=Yellow rubber duck

--- a/tests/test_data/create_booking.xml
+++ b/tests/test_data/create_booking.xml
@@ -1,0 +1,11 @@
+<booking>
+    <firstname>Romuald</firstname>
+    <lastname>Mean</lastname>
+    <totalprice>111</totalprice>
+    <depositpaid>true</depositpaid>
+    <bookingdates>
+        <checkin>2020-03-12</checkin>
+        <checkout>2020-03-25</checkout>
+    </bookingdates>
+    <additionalneeds>Yellow rubber duck</additionalneeds>
+</booking>


### PR DESCRIPTION
This PR extends the basic test case for creating booking endpoint by parametrize decorator.
The content types our API supports:
- application/json
- application/xml
- application/x-www-form-urlencoded

Now each endpoint's content type is covered by tests.